### PR TITLE
Enrich vpc component

### DIFF
--- a/ext/cfndsl/sg.rb
+++ b/ext/cfndsl/sg.rb
@@ -1,0 +1,55 @@
+require 'netaddr'
+
+def sg_create_rules (security_groups, ip_blocks={})
+  rules = []
+  security_groups.each do | group |
+    group['ips'].each do |ip|
+      group['rules'].each do |rule|
+        lookup_ips_for_sg(ip_blocks, ip).each do |cidrs|
+          (cidrs.kind_of?(Array) ? cidrs : [cidrs]).each do |cidr|
+            rules << { IpProtocol: "#{rule['IpProtocol']}", FromPort: "#{rule['FromPort']}", ToPort: "#{rule['ToPort']}", CidrIp: cidr }
+          end
+        end
+      end
+    end
+  end
+  return rules
+end
+
+
+def lookup_ips_for_sg (ips, ip_block_name={})
+  cidr = []
+  if ip_block_name == 'stack'
+    cidr = [FnJoin( "", [ "10.", Ref('StackOctet'), ".", "0.0/16" ] )]
+  elsif ips.has_key? ip_block_name
+    ips[ip_block_name].each do |ip|
+      if (ips.include?(ip) || ip_block_name == 'stack')
+        cidr += lookup_ips_for_sg(ips, ip) unless ip == ip_block_name
+      else
+        if ip == 'stack'
+          cidr << [FnJoin( "", [ "10.", Ref('StackOctet'), ".", "0.0/16" ] )]
+        elsif(isCidr(ip))
+          cidr << ip
+        else
+          STDERR.puts("WARN: ip #{ip} is not a valid CIDR. Ignoring IP")
+        end
+      end
+    end
+  else
+    if isCidr(ip_block_name)
+      cidr = [ip_block_name]
+    else
+      STDERR.puts("WARN: ip #{ip_block_name} is not a valid CIDR. Ignoring IP")
+    end
+  end
+  cidr
+end
+
+def isCidr(block)
+  begin
+    NetAddr::CIDR.create(block)
+    return block.include?('/')
+  rescue NetAddr::ValidationError
+    return false
+  end
+end

--- a/vpc.config.yaml
+++ b/vpc.config.yaml
@@ -14,6 +14,18 @@ subnets:
     allocation: 0
     name: Public
     type: public
+  compute:
+    allocation: 1
+    name: Compute
+    type: private
+  persistence:
+    allocation: 2
+    name: Persistence
+    type: private
+  cache:
+    allocation: 3
+    name: Cache
+    type: private
 
 enable_transit_vpc: false
 


### PR DESCRIPTION
## New features


### Subnets
Idea is that other components can pull subnets in easily with 4 default subnets
- public
- compute
- persistence
- cache

### Improvements

## Pulled in security group methods in vpc component. so any components using this can pull it  in with 

```
   DependsOn 'vpc@1.2.0'
```

This is also requirement for cleaning core library of any cloudformation related functionality (this should be all within components themselves).  

## Bug fixes

This PR also fixes bug in core related to resolving IP blocks within `sg_create_rules` method. 
For certain configuration (below, taken from loadbalancer component)

```
ip_blocks:
  public:
    - 0.0.0.0/0
  internal:
    - stack
```

stack ips were rendered as array of 1 ip, rather than ip itself, resulting in error message below
![alt text](https://www.dropbox.com/s/apxdwulsy3zaxvy/Screenshot%202018-06-21%2019.49.27.png?dl=1 "error screenshot")



