### PR TITLE
remove export for nat ip address to support using eip allocations instead of creating EIPs

### DIFF
--- a/vpc.cfndsl.rb
+++ b/vpc.cfndsl.rb
@@ -236,7 +236,6 @@ CloudFormation do
   nat_ip_list = nat_gateway_ips_list_internal(maximum_availability_zones)
   Output('NatGatewayIps') {
     Value(FnJoin(',', nat_ip_list))
-    Export FnSub("${EnvironmentName}-#{component_name}-NatGatewayIps")
   }
 
 end


### PR DESCRIPTION
Need to probably look to make the export conditional if it is actually required