### PR TITLE
 optionally allow for managed ns records for the environments hosted zone

### DIFF
--- a/vpc.cfhighlander.rb
+++ b/vpc.cfhighlander.rb
@@ -64,4 +64,9 @@ CfhighlanderTemplate do
     end
 
   end
+
+  Component template: 'route53-zone@1.0.2', name: 'dnszone', render: Inline do
+    parameter name: 'CreateZone', value: 'true'
+    parameter name: 'RootDomainName', value: FnSub('${DnsDomain}.')
+  end if manage_ns_records
 end

--- a/vpc.cfndsl.rb
+++ b/vpc.cfndsl.rb
@@ -236,7 +236,6 @@ CloudFormation do
   nat_ip_list = nat_gateway_ips_list_internal(maximum_availability_zones)
   Output('NatGatewayIps') {
     Value(FnJoin(',', nat_ip_list))
-    Export FnSub("${EnvironmentName}-#{component_name}-NatGatewayIps")
   }
 
 end

--- a/vpc.config.yaml
+++ b/vpc.config.yaml
@@ -29,6 +29,14 @@ subnets:
 
 enable_transit_vpc: false
 
+# Manage the NS Records for the VPCs public hosted zone
+# when `true` enables the propergation of NS record into either a parent
+# zone in the same account of via a custom resource another AWS account
+# requires a custom role in the other aws account allowing upsert 
+# permissions to the parent zone
+manage_ns_records: false 
+#is false by default for backward compatibilty
+
 #
 # NACL Rules
 #


### PR DESCRIPTION
Supports adding ns records to a parent zone in the same account or using a cross account IAM role adding the ns records to a hosted zone in another account.

The change is for now opt-in but setting the `manage_ns_records` config value to true and then supplying the required stack parameters. It should be possible to enabling this on existing VPCs as the Hosted Zone created by the route53-zone component is compatible with the existing one but this might need some additional testing and hence having it opt-in

Also includes the removal of the export for the nat-gateway ips