### PR TITLE
Set subnet lists to only use available subnets

### DIFF
--- a/vpc.cfndsl.rb
+++ b/vpc.cfndsl.rb
@@ -175,8 +175,9 @@ CloudFormation do
       end
       subnetRefs << Ref(subnet_name_az)
     end
+    subnet_list = az_conditional_resources_internal("Subnet#{config['name']}",maximum_availability_zones)
     Output("#{config['name']}Subnets") {
-      Value(FnJoin(',', subnetRefs))
+      Value(FnJoin(',', subnet_list))
       Export FnSub("${EnvironmentName}-#{component_name}-#{config['name']}Subnets")
     }
   }


### PR DESCRIPTION
Prevents current error when deploying cloudformation when maximum_availability_zones is greater than the AZ'z available in a Region.
